### PR TITLE
Add OnErrorCallback::ignoreError named constructor to allow easily ignore errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 - Copy `$response` in `ProfilerItem` not to store a reference to the original object
+- Add `OnErrorCallback::ignoreError` named constructor
 
 ## 1.0.0 - 2021-05-12
 - Initial implementation

--- a/src/ValueObject/OnErrorCallback.php
+++ b/src/ValueObject/OnErrorCallback.php
@@ -17,6 +17,11 @@ class OnErrorCallback implements OnErrorInterface
         });
     }
 
+    public static function ignoreError(): self
+    {
+        return new self(function (\Throwable $error): void {});
+    }
+
     /**
      * @phpstan-param callable(\Throwable): void $callback
      */

--- a/tests/ValueObject/OnErrorCallbackTest.php
+++ b/tests/ValueObject/OnErrorCallbackTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Cqrs\Types\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+
+class OnErrorCallbackTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldUseGivenCallback(): void
+    {
+        $actualError = null;
+
+        $callback = new OnErrorCallback(function (\Throwable $error) use (&$actualError): void {
+            $actualError = $error->getMessage();
+        });
+
+        $callback(new \Exception('Actual error'));
+
+        $this->assertSame('Actual error', $actualError);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldThrowGivenError(): void
+    {
+        $callback = OnErrorCallback::throwOnError();
+
+        $this->expectExceptionMessage('Should be thrown.');
+
+        $callback(new \Exception('Should be thrown.'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldIgnoreError(): void
+    {
+        $callback = OnErrorCallback::ignoreError();
+
+        $callback(new \Exception('Should not be thrown.'));
+
+        $this->expectNotToPerformAssertions();
+    }
+}


### PR DESCRIPTION
This should be used in a scenario, where you have some default value for an error path and you don't care whether there is an error.