### PR TITLE
Add initiator to response decoder interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- There should always be "Unreleased" section at the beginning. -->
 
 ## Unreleased
+- [**BC**] Add `$initiator` argument to `ResponseDecoderInterface::supports` method
 
 ## 1.1.0 - 2021-07-28
 - Copy `$response` in `ProfilerItem` not to store a reference to the original object

--- a/src/Decoder/CallbackResponseDecoder.php
+++ b/src/Decoder/CallbackResponseDecoder.php
@@ -10,7 +10,7 @@ namespace Lmc\Cqrs\Types\Decoder;
 class CallbackResponseDecoder implements ResponseDecoderInterface
 {
     /**
-     * @phpstan-var callable(mixed): bool
+     * @phpstan-var callable(mixed, mixed): bool
      * @var callable
      */
     private $supports;
@@ -21,7 +21,7 @@ class CallbackResponseDecoder implements ResponseDecoderInterface
     private $decode;
 
     /**
-     * @phpstan-param callable(mixed): bool $supports
+     * @phpstan-param callable(mixed, mixed): bool $supports
      * @phpstan-param callable(Response): DecodedResponse $decode
      */
     public function __construct(callable $supports, callable $decode)
@@ -30,12 +30,9 @@ class CallbackResponseDecoder implements ResponseDecoderInterface
         $this->decode = $decode;
     }
 
-    /**
-     * @param mixed $response
-     */
-    public function supports($response): bool
+    public function supports($response, $initiator): bool
     {
-        return call_user_func($this->supports, $response);
+        return call_user_func($this->supports, $response, $initiator);
     }
 
     /**

--- a/src/Decoder/JsonResponseDecoder.php
+++ b/src/Decoder/JsonResponseDecoder.php
@@ -7,7 +7,7 @@ namespace Lmc\Cqrs\Types\Decoder;
  */
 class JsonResponseDecoder implements ResponseDecoderInterface
 {
-    public function supports($response): bool
+    public function supports($response, $initiator): bool
     {
         return is_string($response) && is_array(json_decode($response, true));
     }

--- a/src/Decoder/ResponseDecoderInterface.php
+++ b/src/Decoder/ResponseDecoderInterface.php
@@ -12,8 +12,9 @@ interface ResponseDecoderInterface
 {
     /**
      * @param mixed $response
+     * @param mixed $initiator
      */
-    public function supports($response): bool;
+    public function supports($response, $initiator): bool;
 
     /**
      * Note: If your decode method returns a DecodedValue - it won't be further decoded by any other decoder.

--- a/tests/Decoder/CallbackResponseDecoderTest.php
+++ b/tests/Decoder/CallbackResponseDecoderTest.php
@@ -9,15 +9,29 @@ class CallbackResponseDecoderTest extends TestCase
     /**
      * @test
      */
-    public function shouldSupportsByGivenCallback(): void
+    public function shouldSupportsResponseByGivenCallback(): void
     {
         $decoder = new CallbackResponseDecoder(
-            'is_string',
+            fn (string $response, $initiator) => $response === 'response',
             fn (string $response) => sprintf('decoded:%s', $response),
         );
 
-        $this->assertTrue($decoder->supports('response'));
-        $this->assertFalse($decoder->supports(42));
+        $this->assertTrue($decoder->supports('response', null));
+        $this->assertFalse($decoder->supports(42, null));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSupportsInitiatorByGivenCallback(): void
+    {
+        $decoder = new CallbackResponseDecoder(
+            fn (string $response, ?string $initiator) => $initiator === 'initiator',
+            fn (string $response) => sprintf('decoded:%s', $response),
+        );
+
+        $this->assertTrue($decoder->supports('response', 'initiator'));
+        $this->assertFalse($decoder->supports('response', null));
     }
 
     /**
@@ -26,7 +40,7 @@ class CallbackResponseDecoderTest extends TestCase
     public function shouldDecodeByGivenCallback(): void
     {
         $decoder = new CallbackResponseDecoder(
-            'is_string',
+            fn (string $response, $initiator) => is_string($response),
             fn (string $response) => sprintf('decoded:%s', $response),
         );
 

--- a/tests/Decoder/JsonResponseDecoderTest.php
+++ b/tests/Decoder/JsonResponseDecoderTest.php
@@ -17,7 +17,7 @@ class JsonResponseDecoderTest extends TestCase
     {
         $decoder = new JsonResponseDecoder();
 
-        $this->assertSame($supports, $decoder->supports($input));
+        $this->assertSame($supports, $decoder->supports($input, null));
         $this->assertSame($expected, $decoder->decode($input));
     }
 


### PR DESCRIPTION
This is quite a change, since it must be implemented in all other libraries, but it adds a major feature for a ResponseDecoders.

Now a ResponseDecoder is used for both CommandInterface and QueryInterface responses and there is no way how to make a decoder to decode response of a particular Query or Command, it is only determined by a response itself.

This may be problem if you have a specific query with "generic" response (_such as json_). Json will be decoded by JsonResponseDecoder to array. If you want to decode that array into some object in your decoder, you have to "guess" the response by its attributes, because it is just an array decoded from json.

So the Initiator comes handy, because it is an instance of a Query/Command initiated the response, so you can just check a class or whatever to determine it is a response of **the** Query/Command.

As a bonus it adds a possibility to create a response decoder for either QueryInterface or CommandInterface by simply checking the interface of an initiator.
```php
public function supports($response, $initiator): bool
{
    return $initiator instanceof QueryInterace /* && check response */;
}
```

**NOTE**: it won't change a behaviour of any existing response decoder implemented in the libraries.