### PR TITLE
Copy response in profilerItem not to store a reference to the original object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- There should always be "Unreleased" section at the beginning. -->
 
 ## Unreleased
+- Copy `$response` in `ProfilerItem` not to store a reference to the original object
 
 ## 1.0.0 - 2021-05-12
 - Initial implementation

--- a/src/ValueObject/ProfilerItem.php
+++ b/src/ValueObject/ProfilerItem.php
@@ -49,8 +49,8 @@ class ProfilerItem
         $this->itemType = $this->matchItemType($itemType);
 
         $this->type = $type;
-        $this->response = $response;
-        $this->error = $error;
+        $this->setResponse($response);
+        $this->setError($error);
         $this->cacheKey = $cacheKey;
         $this->isLoadedFromCache = $isLoadedFromCache;
         $this->isStoredInCache = $isStoredInCache;
@@ -112,7 +112,18 @@ class ProfilerItem
     /** @param mixed|FormattedValue<mixed, mixed> $response */
     public function setResponse($response): void
     {
-        $this->response = $response;
+        $this->response = $this->copy($response);
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    private function copy($value)
+    {
+        return is_object($value)
+            ? clone $value
+            : $value;
     }
 
     /** @return \Throwable|FormattedValue<mixed, mixed>|null */

--- a/tests/ValueObject/ProfilerItemTest.php
+++ b/tests/ValueObject/ProfilerItemTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Lmc\Cqrs\Types\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+
+class ProfilerItemTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldProfileResponseAsItIsInThatMoment(): void
+    {
+        $response = new \stdClass();
+        $response->value = 'foo';
+
+        $profilerItem = new ProfilerItem('id', null, 'test', null, $response);
+
+        $response->value = 'fooBar';
+
+        $this->assertSame('foo', $profilerItem->getResponse()->value);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldProfileResponseAsItIsInThatMomentViaSetter(): void
+    {
+        $response = new \stdClass();
+        $response->value = 'foo';
+
+        $profilerItem = new ProfilerItem('id', null, 'test');
+        $profilerItem->setResponse($response);
+
+        $response->value = 'fooBar';
+
+        $this->assertSame('foo', $profilerItem->getResponse()->value);
+    }
+}


### PR DESCRIPTION
This is because of an automatic object referencing - it is weird that your decoded response is cached in a different shape then it is shown in the profiler, which may occur if you change the object after it is returned from a `QueryFetcher` but it is not yet shown in the profiler (it would show the new updated version, not the one really decoded in the QueryFetcher and cached, if the Query is cacheable).